### PR TITLE
Bugfix/grep

### DIFF
--- a/plugins/t/10_check_multi.t.in
+++ b/plugins/t/10_check_multi.t.in
@@ -58,7 +58,7 @@ like(
 #--- ENV vars MULTI_... via command --------------------------------------------
 #-------------------------------------------------------------------------------
 $result = NPTest->testCmd(
-	"@PERL@ ../check_multi -r 1+4 $testopts -x 'command [ echo ] = echo \"Hello World\"' -x 'command [ env ] = env | grep MULTI | sort' -r 1+4",
+	"@PERL@ ../check_multi -r 1+4 $testopts -x 'command [ echo ] = echo \"Hello World\"' -x 'command [ env ] = env | grep ^MULTI_ | sort' -r 1+4",
 );
 is(
 	$result->return_code, 
@@ -83,7 +83,7 @@ like(
 #--- ENV vars MULTI_... via eval -----------------------------------------------
 #-------------------------------------------------------------------------------
 $result = NPTest->testCmd(
-	"@PERL@ ../check_multi $testopts -x 'eeval [ echo ] = \"Hello World\";' -x 'command [ env ] = env | grep MULTI | sort' -r 1+4",
+	"@PERL@ ../check_multi $testopts -x 'eeval [ echo ] = \"Hello World\";' -x 'command [ env ] = env | grep ^MULTI_ | sort' -r 1+4",
 );
 is(
 	$result->return_code, 

--- a/plugins/t/20_check_multi_macros.t.in
+++ b/plugins/t/20_check_multi_macros.t.in
@@ -36,7 +36,7 @@ my $testopts=testopts::get_testopts;
 #--- ENV vars MULTI_... via command --------------------------------------------
 #-------------------------------------------------------------------------------
 $result = NPTest->testCmd(
-	"@PERL@ ../check_multi $testopts -x 'command [ echo ] = echo \"Hello World\"' -x 'command [ env ] = env | grep MULTI | sort' -r 1+4",
+	"@PERL@ ../check_multi $testopts -x 'command [ echo ] = echo \"Hello World\"' -x 'command [ env ] = env | grep ^MULTI_ | sort' -r 1+4",
 );
 is(
 	$result->return_code, 
@@ -61,7 +61,7 @@ like(
 #--- ENV vars MULTI_... via eval -----------------------------------------------
 #-------------------------------------------------------------------------------
 $result = NPTest->testCmd(
-	"@PERL@ ../check_multi $testopts -x 'eeval [ echo ] = \"Hello World\";' -x 'command [ env ] = env | grep MULTI | sort' -r 1+4",
+	"@PERL@ ../check_multi $testopts -x 'eeval [ echo ] = \"Hello World\";' -x 'command [ env ] = env | grep ^MULTI_ | sort' -r 1+4",
 );
 is(
 	$result->return_code, 


### PR DESCRIPTION
When a variable containing the substring MULTI appears in the build environment, "make test" aborts with an error.  To fix this, I made grep more specific.

To be specific: When building debian packages with "sbuild" inside a clean chroot, the variable DEB_BUILD_MULTIARCH=x86_64-linux-gnu appears, confusing the test.
