### PR TITLE
Fix template name when command has no parameter

### DIFF
--- a/plugins/check_multi.in
+++ b/plugins/check_multi.in
@@ -1725,10 +1725,10 @@ sub parse_header {
 		my $plugin="";
 		if ($cmd=~/\s+/) {
 			$plugin=(split(/\s+/,"$cmd"))[0];
-			$plugin=~s/.*\///g; 	# basename(plugin) (thx Gerhard)
 		} else {
 			$plugin=$cmd;
 		}
+		$plugin=~s/.*\///g; 	# basename(plugin) (thx Gerhard)
 
 		$cmds[$i]{type}=$type;
 		$cmds[$i]{name}=$name;

--- a/plugins/check_multi.in
+++ b/plugins/check_multi.in
@@ -30,7 +30,6 @@ $DETAIL_LIST $DETAIL_LIST_FULL $DETAIL_HTML $DETAIL_STDERR $DETAIL_PERFORMANCE
 $DETAIL_PERFORMANCE_CLASSIC $DETAIL_STATUS $DETAIL_PERFORMANCE_LINK $DETAIL_XML $DETAIL_NAGIOS2
 $DETAIL_NOTES_LINK $DETAIL_SERVICE_DEFINITION $DETAIL_SEND_NSCA $DETAIL_FEED_PASSIVE
 $DETAIL_ENCODE_COMMANDS $DETAIL_HIDEIFOK $DETAIL_SEND_GEARMAN
-*DEBUG0 *DEBUG1 *DEBUG2 *DEBUG3 *DEBUG4
 );
 BEGIN {
 	#--- OMD environment? Then we have to be sure that vars are defined
@@ -359,6 +358,14 @@ my $check_multi = {
 #-------------------------------------------------------------------------------
 
 #---
+#--- Dummy subs for defaults, used before parameter parsing is done
+#---
+sub DEBUG1 {}
+sub DEBUG2 {}
+sub DEBUG3 {}
+sub DEBUG4 {}
+
+#---
 #--- process command line parameters and STDIN (if any)
 #---
 sub process_input {
@@ -395,10 +402,13 @@ sub process_input {
 	}
 
 	#--- 4 debug levels: 1. verbose 2. errors 3. detailed 4. programmers debugging
-	*DEBUG1=($opt{set}{verbose}>=1) ? \&debug_message : sub {};
-	*DEBUG2=($opt{set}{verbose}>=2) ? \&debug_message : sub {};
-	*DEBUG3=($opt{set}{verbose}>=3) ? \&debug_message : sub {};
-	*DEBUG4=($opt{set}{verbose}>=3) ? \&debug_message : sub {};
+    {
+        no warnings 'redefine';
+	    *DEBUG1=($opt{set}{verbose}>=1) ? \&debug_message : sub {};
+	    *DEBUG2=($opt{set}{verbose}>=2) ? \&debug_message : sub {};
+	    *DEBUG3=($opt{set}{verbose}>=3) ? \&debug_message : sub {};
+	    *DEBUG4=($opt{set}{verbose}>=3) ? \&debug_message : sub {};
+    }
 
 	#--- -V(ersion) option
 	if ($opt{version}) {

--- a/plugins/check_multi.in
+++ b/plugins/check_multi.in
@@ -372,12 +372,6 @@ sub process_input {
 		return $UNKNOWN;
 	}
 
-	#--- 4 debug levels: 1. verbose 2. errors 3. detailed 4. programmers debugging
-	*DEBUG1=($opt{set}{verbose}>=1) ? \&debug_message : sub {};
-	*DEBUG2=($opt{set}{verbose}>=2) ? \&debug_message : sub {};
-	*DEBUG3=($opt{set}{verbose}>=3) ? \&debug_message : sub {};
-	*DEBUG4=($opt{set}{verbose}>=3) ? \&debug_message : sub {};
-
 	if (! GetOptions(
 		"f|filename=s"	=> \@{$opt{filename}},
 		"h|help:+"	=> \$opt{help},
@@ -401,10 +395,10 @@ sub process_input {
 	}
 
 	#--- 4 debug levels: 1. verbose 2. errors 3. detailed 4. programmers debugging
-	undef *DEBUG1; *DEBUG1=($opt{set}{verbose}>=1) ? \&debug_message : sub {};
-	undef *DEBUG2; *DEBUG2=($opt{set}{verbose}>=2) ? \&debug_message : sub {};
-	undef *DEBUG3; *DEBUG3=($opt{set}{verbose}>=3) ? \&debug_message : sub {};
-	undef *DEBUG4; *DEBUG4=($opt{set}{verbose}>=3) ? \&debug_message : sub {};
+	*DEBUG1=($opt{set}{verbose}>=1) ? \&debug_message : sub {};
+	*DEBUG2=($opt{set}{verbose}>=2) ? \&debug_message : sub {};
+	*DEBUG3=($opt{set}{verbose}>=3) ? \&debug_message : sub {};
+	*DEBUG4=($opt{set}{verbose}>=3) ? \&debug_message : sub {};
 
 	#--- -V(ersion) option
 	if ($opt{version}) {


### PR DESCRIPTION
Gerhard made a patch to strip the path out of a command, but this code was only used when the command had parameters.

I had a command without parameters, and it wasn't stripped out. First commit fixes that.
Second commits just simplifies the DEBUG code. It didn't work in my version, and I have no idea why you fixed it that way before.
