### PR TITLE
nagios2 mode broken by extinfo_in_status=0 option

### DIFF
--- a/plugins/check_multi.in
+++ b/plugins/check_multi.in
@@ -3654,7 +3654,7 @@ sub report_html {
 
 	#--- print general errors if any occured
 	$output.=error(0);
-	$output.=($opt{set}{extinfo_in_status})?"<br />":"\n";
+	$output.=($opt{set}{extinfo_in_status})?"<br />": (($opt{set}{report} & $DETAIL_NAGIOS2) ? ". " : "\n");
 
 	#--- collapse of contents with javascript
 	if ($opt{set}{collapse} == 1) {


### PR DESCRIPTION
nagios2 mode should output _everything_ on one line, however if
extinfo_in_status=0 newline slips in after main plugin status report

use period in nagios2 mode
