### PR TITLE
allow compile default path for nagiostats

### DIFF
--- a/sample_config/nagiostats/nagiostats.cmd.in
+++ b/sample_config/nagiostats/nagiostats.cmd.in
@@ -8,6 +8,8 @@
 # Call: check_multi -f nagiostats.cmd -s NSTATS=/path/to/nagiostats
 #
 
+eval [ NSTATS ] = ("$NSTATS$" eq "") ? "@sbindir@/nagiostats" : "$NSTATS$"
+
 # 1. check correct parameter passing for NSTAT binary
 eval    [ NSTATS_defined                ] =
 	if (! "$NSTATS$") {


### PR DESCRIPTION
so that configure time sbinpath applies (like elsewhere)
