### PR TITLE
Add test script directory perl search path.

### DIFF
--- a/plugins/t/10_check_multi.t.in
+++ b/plugins/t/10_check_multi.t.in
@@ -5,6 +5,8 @@
 #
 use strict;
 use Test::More;
+use FindBin;
+use lib "$FindBin::Bin";
 use NPTest;
 use testopts;
 

--- a/plugins/t/15_check_multi_history.t.in
+++ b/plugins/t/15_check_multi_history.t.in
@@ -6,6 +6,8 @@
 
 use strict;
 use Test::More;
+use FindBin;
+use lib "$FindBin::Bin";
 use NPTest;
 use testopts;
 

--- a/plugins/t/20_check_multi_macros.t.in
+++ b/plugins/t/20_check_multi_macros.t.in
@@ -6,6 +6,8 @@
 
 use strict;
 use Test::More;
+use FindBin;
+use lib "$FindBin::Bin";
 use NPTest;
 use testopts;
 

--- a/plugins/t/30_check_multi_perfdata.t.in
+++ b/plugins/t/30_check_multi_perfdata.t.in
@@ -6,6 +6,8 @@
 
 use strict;
 use Test::More;
+use FindBin;
+use lib "$FindBin::Bin";
 use NPTest;
 use testopts;
 

--- a/plugins/t/50_check_multi_checkresults.t.in
+++ b/plugins/t/50_check_multi_checkresults.t.in
@@ -6,6 +6,8 @@
 
 use strict;
 use Test::More;
+use FindBin;
+use lib "$FindBin::Bin";
 use NPTest;
 use testopts;
 

--- a/plugins/t/60_check_multi_feeds_passive.t.in
+++ b/plugins/t/60_check_multi_feeds_passive.t.in
@@ -6,6 +6,8 @@
 
 use strict;
 use Test::More;
+use FindBin;
+use lib "$FindBin::Bin";
 use NPTest;
 use testopts;
 

--- a/plugins/t/70_check_multi_statusdat.t.in
+++ b/plugins/t/70_check_multi_statusdat.t.in
@@ -6,6 +6,8 @@
 
 use strict;
 use Test::More;
+use FindBin;
+use lib "$FindBin::Bin";
 use NPTest;
 use testopts;
 

--- a/plugins/t/80_check_multi_livestatus.t.in
+++ b/plugins/t/80_check_multi_livestatus.t.in
@@ -6,6 +6,8 @@
 
 use strict;
 use Test::More;
+use FindBin;
+use lib "$FindBin::Bin";
 use NPTest;
 use testopts;
 

--- a/plugins/t/90_extreme_tags.t.in
+++ b/plugins/t/90_extreme_tags.t.in
@@ -6,6 +6,8 @@
 
 use strict;
 use Test::More;
+use FindBin;
+use lib "$FindBin::Bin";
 use NPTest;
 use testopts;
 

--- a/plugins/t/91_extreme_timeout.t.in
+++ b/plugins/t/91_extreme_timeout.t.in
@@ -6,6 +6,8 @@
 
 use strict;
 use Test::More;
+use FindBin;
+use lib "$FindBin::Bin";
 use NPTest;
 use testopts;
 


### PR DESCRIPTION
To fix CVE-2016-1238 `.` has been removed from `@INC`.