### PR TITLE
scape left brace in regex.

### DIFF
--- a/plugins/check_multi.in
+++ b/plugins/check_multi.in
@@ -1362,7 +1362,7 @@ sub parse_objects_cache {
 	}
 	while (<OBJECTS_CACHE>) {
 		#--- begin of object, determine type
-		if (/^define ([a-z0-9\_\-]+) {$/) {
+		if (/^define ([a-z0-9\_\-]+) \{$/) {
 			$type="$1";
 			$typelist{$type}++;
 			$objectcount++;


### PR DESCRIPTION
Quoting perldelta:

> A literal "{" should now be escaped in a pattern
>
> If you want a literal left curly bracket (also called a left brace) in
> a regular expression pattern, you should now escape it by either
> preceding it with a backslash ("\{") or enclosing it within square
> brackets "[{]", or by using \Q; otherwise a deprecation warning will be
> raised. This was first announced as forthcoming in the v5.16 release;
> it will allow future extensions to the language to happen.

http://search.cpan.org/dist/perl-5.22.0/pod/perldelta.pod#A_literal_%22{%22_should_now_be_escaped_in_a_pattern

Fixes #12