### PR TITLE
Fix 'Option s requires an argument' test.

### DIFF
--- a/plugins/t/10_check_multi.t.in
+++ b/plugins/t/10_check_multi.t.in
@@ -931,7 +931,7 @@ is(
 );
 like(
 	$result->output,
-	'/OK - 0 plugins checked,  \[Option s requires an argument.*\]/',
+	'/Option s requires an argument/',
 	"output correct",
 );
 #-------------------------------------------------------------------------------

--- a/plugins/t/NPTest.pm
+++ b/plugins/t/NPTest.pm
@@ -617,7 +617,7 @@ sub testCmd {
 	my $command = shift or die "No command passed to testCmd";
 	my $object = $class->new;
 	
-	my $output = `$command`;
+	my $output = `$command 2>&1`;
 	$object->return_code($? >> 8);
 	$_ = $? & 127;
 	if ($_) {


### PR DESCRIPTION
Expected output on `STDERR` instead of `STDOUT`.