### PR TITLE
Fix: "Unescaped left brace in regex" when used with Perl v5.26.3 - an…

### DIFF
--- a/plugins/check_multi.in
+++ b/plugins/check_multi.in
@@ -1362,7 +1362,7 @@ sub parse_objects_cache {
 	}
 	while (<OBJECTS_CACHE>) {
 		#--- begin of object, determine type
-		if (/^define ([a-z0-9\_\-]+) {$/) {
+		if (/^define ([a-z0-9\_\-]+) \{$/) {
 			$type="$1";
 			$typelist{$type}++;
 			$objectcount++;
@@ -4201,7 +4201,7 @@ sub report_all {
 
 	#--- some debugging first
 	DEBUG4("MULTI Environment (sorted):\n\t".join("\n\t",get_env_vars('^MULTI')));
-	DEBUG4("${NAGIOS} Environment (sorted):\n\t".join("\n\t",get_env_vars('^${NAGIOS}')));
+	DEBUG4("${NAGIOS} Environment (sorted):\n\t".join("\n\t",get_env_vars("^${NAGIOS}")));
 
 	#--- construction site for persistence
 	if ($opt{set}{test} && $opt{set}{persistent}) {


### PR DESCRIPTION
…d on that occassion: debug output for ${NAGIOS} env not working working